### PR TITLE
Use Github Actions and Github Packages to publish the Java package

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -2,9 +2,13 @@ name: .NET Core (Linux)
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
+    paths:
+      - "cs/**"
   pull_request:
-    branches: [ master ]
+    branches: [master]
+    paths:
+      - "cs/**"
 
 jobs:
   build:

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -10,30 +10,30 @@ on:
     paths:
       - "cs/**"
 
+defaults:
+  run:
+    working-directory: cs
+
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.101
-    - name: Install dependencies
-      run: |
-        cd cs
-        dotnet restore GS1GMN.sln
-    - name: Build
-      run: |
-        cd cs
-        dotnet build GMN/GMN.csproj --configuration Release --no-restore
-    - name: Test
-      run: |
-        cd cs
-        dotnet test GMNTests/GMNTests.csproj --no-restore --verbosity normal
-    - uses: nikeee/docfx-action@master
-      name: Generate docfx documentation
-      with:
-        args: cs/docfx_project/docfx.json
+      - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.101
+      - name: Install dependencies
+        run: |
+          dotnet restore GS1GMN.sln
+      - name: Build
+        run: |
+          dotnet build GMN/GMN.csproj --configuration Release --no-restore
+      - name: Test
+        run: |
+          dotnet test GMNTests/GMNTests.csproj --no-restore --verbosity normal
+      - uses: nikeee/docfx-action@master
+        name: Generate docfx documentation
+        with:
+          args: docfx_project/docfx.json

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -27,9 +27,12 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - name: Build with Maven
-        run: |
-          mvn -B compile
       - name: Test with Maven
         run: |
           mvn -B test
+      - name: Build with Maven
+        run: mvn clean install
+      - name: Publish package
+        run: mvn --batch-mode deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -13,6 +13,10 @@ on:
     paths:
       - "java/**"
 
+defaults:
+  run:
+    working-directory: java
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -25,9 +29,7 @@ jobs:
           java-version: 1.8
       - name: Build with Maven
         run: |
-          cd java
           mvn -B compile
       - name: Test with Maven
         run: |
-          cd java
           mvn -B test

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -5,26 +5,29 @@ name: Java CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
+    paths:
+      - "java/**"
   pull_request:
-    branches: [ master ]
+    branches: [master]
+    paths:
+      - "java/**"
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
-    - name: Build with Maven
-      run: |
-        cd java
-        mvn -B compile
-    - name: Test with Maven
-      run: |
-        cd java
-        mvn -B test
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build with Maven
+        run: |
+          cd java
+          mvn -B compile
+      - name: Test with Maven
+        run: |
+          cd java
+          mvn -B test

--- a/.github/workflows/mswin.yml
+++ b/.github/workflows/mswin.yml
@@ -10,26 +10,24 @@ on:
     paths:
       - "cs/**"
 
+defaults:
+  run:
+    working-directory: cs
+
 jobs:
-
   ci-mswin:
-
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1
-    - name: MSVC CI
-      working-directory: cs
-      run: dotnet build
+      - uses: actions/checkout@v2
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1
+      - name: MSVC CI
+        run: dotnet build
 
-    - name: Install dependencies
-      working-directory: cs
-      run: dotnet restore GS1GMN.sln
-    - name: Build
-      working-directory: cs
-      run: dotnet build GMN/GMN.csproj --configuration Release --no-restore
-    - name: Test
-      working-directory: cs
-      run: dotnet test GMNTests/GMNTests.csproj --no-restore --verbosity normal
+      - name: Install dependencies
+        run: dotnet restore GS1GMN.sln
+      - name: Build
+        run: dotnet build GMN/GMN.csproj --configuration Release --no-restore
+      - name: Test
+        run: dotnet test GMNTests/GMNTests.csproj --no-restore --verbosity normal

--- a/.github/workflows/mswin.yml
+++ b/.github/workflows/mswin.yml
@@ -2,9 +2,13 @@ name: .NET Core (Windows)
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
+    paths:
+      - "cs/**"
   pull_request:
-    branches: [ master ]
+    branches: [master]
+    paths:
+      - "cs/**"
 
 jobs:
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,6 +13,10 @@ on:
     paths:
       - "js/**"
 
+defaults:
+  run:
+    working-directory: js
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -29,13 +33,10 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Build
         run: |
-          cd js
           npm install
       - name: Test
         run: |
-          cd js
           npm test
       - name: Lint
         run: |
-          cd js
           npm run lint

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,13 +5,16 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
+    paths:
+      - "js/**"
   pull_request:
-    branches: [ master ]
+    branches: [master]
+    paths:
+      - "js/**"
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -19,20 +22,20 @@ jobs:
         node-version: [10.x, 12.x]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Build
-      run: |
-        cd js
-        npm install
-    - name: Test
-      run: |
-        cd js
-        npm test
-    - name: Lint
-      run: |
-        cd js
-        npm run lint
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Build
+        run: |
+          cd js
+          npm install
+      - name: Test
+        run: |
+          cd js
+          npm test
+      - name: Lint
+        run: |
+          cd js
+          npm run lint

--- a/README.md
+++ b/README.md
@@ -109,3 +109,24 @@ The initial libraries and tests were written (under the commission of GS1 AISBL)
 by one of the experts in the technical group that selected the algorithm based
 on its performance during the analysis of several alternative schemes under
 consideration.
+
+Installation
+------------
+
+Using Maven
+```xml
+<dependencies>
+ <dependency>
+    <groupId>org.gs1</groupId>
+    <artifactId>GMN</artifactId>
+    <version>1.0</version>
+  </dependency>
+</dependencies>
+```
+
+Using Gradle
+```kotlin
+dependencies {
+    implementation("org.gs1:GMN:1.0")
+}
+```

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.gs1</groupId>
@@ -16,6 +15,14 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
+
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/gs1/gmn-helpers</url>
+        </repository>
+    </distributionManagement>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
**This PR primarily focuses on the implementation of the Java GS1 helper. Once approved, similar implementations in other languages will follow.**

## Changes made:

- Refactored Github actions to utilize working directories instead of navigating into each subdirectory.
- Implemented deployment of the final build to Github Packages using Maven, enabling users to download it with both Gradle and Maven.
- Specified the Github Package Registry within distributionManagement to inform Maven about the deployment destination.


## Noteworthy:

Currently, Github actions are disabled for this repository, preventing me from testing these changes as I typically do. Furthermore, due to the disabled GH Issue feature, I couldn't discuss the use of Actions for deploying to common registries earlier. I believe this could greatly benefit the project in the future, making it more inviting for contributors and facilitating discussions.